### PR TITLE
Use User.userAuthToken instead of User.id in session cookie

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,9 +8,10 @@ datasource db {
 }
 
 model User {
-  id           String   @id @default(uuid())
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
-  username     String   @unique
-  passwordHash String
+  id            String   @id @default(uuid())
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  username      String   @unique
+  passwordHash  String
+  userAuthToken String   @defualt(cuid())
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,5 +13,5 @@ model User {
   updatedAt     DateTime @updatedAt
   username      String   @unique
   passwordHash  String
-  userAuthToken String   @defualt(cuid())
+  userAuthToken String   @defualt(cuid()) @unique
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -15,7 +15,7 @@ export const handle: Handle = async ({
   }
 
   const session = await db.user.findUnique({
-    where: { id: cookies.session },
+    where: { userAuthToken: cookies.session },
   })
 
   if (session) {

--- a/src/routes/auth/login/index.ts
+++ b/src/routes/auth/login/index.ts
@@ -54,7 +54,7 @@ export const post: RequestHandler = async ({ request }) => {
       success: 'Success.',
     },
     headers: {
-      'Set-Cookie': cookie.serialize('session', user.id, {
+      'Set-Cookie': cookie.serialize('session', user.userAuthToken, {
         // send cookie for every page
         path: '/',
         // server side only cookie so you can't use `document.cookie`


### PR DESCRIPTION
This is a simple change but creates a safer auth. if someone creates a /u/:[id] route and links user profiles, then users can simply copy the [id] from the URL and set their auth cookie to that user's id, and access that account.

this just creates a 'userAuthToken' column that replaces the user id in the session cookie, when adding an API, make sure this column is hidden (as well as passwordHash obviously).